### PR TITLE
#9 add test coverage

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -21,4 +21,4 @@ jobs:
         with:
           java-version: "adopt@1.8"
       - name: Build and run tests
-        run: sbt test
+        run: sbt coverage test coverageReport

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.0.0")
+
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.10")
 
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")


### PR DESCRIPTION
Adding unittest code coverage report into CI/CD GitHub Actions file so that we can see code coverage at least there. Maybe we can use this in other repositories as well and perhaps later put the coverage info on Readme as an additional badge.