### PR TITLE
#6 setting the same CI/CD definition as in the sbt-ci-release one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,12 +5,11 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
-      - uses: olafurpg/setup-scala@v10
+      - uses: olafurpg/setup-scala@v13
       - run: sbt ci-release
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}


### PR DESCRIPTION
The problem can be seen in the second or third Release, see the logs: https://github.com/AbsaOSS/sbt-git-hooks/actions/workflows/release.yml. It says: _"Snapshot releases must have -SNAPSHOT version number, doing nothing"_

This is coming from here: https://github.com/sbt/sbt-ci-release/blob/main/plugin/src/main/scala/com/geirsson/CiReleasePlugin.scala#L154= because value `isTag` is obviously False - but there already is a git tag on master. And it gets fetched by the CI - just not into the system env variable `GITHUB_REF`.

---
Possible reasons why this occurred:

1. I checked the https://github.com/actions/runner/issues, but couldn't find any reported problem with `workflow_dispatch` not having `refs/tags` available in `GITHUB_REF` (that doesn't mean that there isn't a bug in it, or missing piece of information in the documentation)
2. Bug in older version of https://github.com/actions/checkout/releases that is used at the moment. I'll try to update it to the most recent version and we'll see if that works.