### PR TITLE
#6 sonatypeProfileName must be located on the root level

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,7 @@ lazy val root = (project in file("."))
   .settings(
     sbtPlugin := true,
     name := "sbt-git-hooks",
+    sonatypeProfileName := "za.co.absa",
     libraryDependencies ++= dependencies,
     scriptedLaunchOpts := { scriptedLaunchOpts.value ++
       Seq("-Xmx1024M", "-Dplugin.version=" + version.value)

--- a/publish.sbt
+++ b/publish.sbt
@@ -13,8 +13,6 @@
  * limitations under the License.
  */
 
-ThisBuild / sonatypeProfileName := "za.co.absa"
-
 ThisBuild / organizationName := "ABSA Group Limited"
 ThisBuild / organizationHomepage := Some(url("https://www.absa.africa"))
 ThisBuild / scmInfo := Some(


### PR DESCRIPTION
Tested with `sbt` command by printing values 'organization' and 'sonatypeProfileName' - finally, both of them store expected values.