### PR TITLE
#8 adding versionScheme and Release status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 [![Release](https://github.com/AbsaOSS/sbt-git-hooks/actions/workflows/release.yml/badge.svg)](https://github.com/AbsaOSS/sbt-git-hooks/actions/workflows/release.yml)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/za.co.absa.sbt/sbt-git-hooks_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/za.co.absa.sbt/sbt-git-hooks_2.12)
 
 sbt-git-hooks is an [sbt](http://www.scala-sbt.org) plugin for maintaining git hooks as part of your code.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
 [![Release](https://github.com/AbsaOSS/sbt-git-hooks/actions/workflows/release.yml/badge.svg)](https://github.com/AbsaOSS/sbt-git-hooks/actions/workflows/release.yml)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/za.co.absa.sbt/sbt-git-hooks_2.12/badge.svg)](https://maven-badges.herokuapp.com/maven-central/za.co.absa.sbt/sbt-git-hooks_2.12)
 
 sbt-git-hooks is an [sbt](http://www.scala-sbt.org) plugin for maintaining git hooks as part of your code.
 
@@ -41,3 +42,7 @@ To check which files would get synced and what would happen run `sbt getGitHooks
 
 - Java 8 or higher
 - sbt 1.3.0 or higher
+
+## How to Release
+
+Please see [this file](RELEASE.md) for more details.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # sbt-git-hooks
 
 [![License](http://img.shields.io/:license-apache-blue.svg)](http://www.apache.org/licenses/LICENSE-2.0.html)
+[![Release](https://github.com/AbsaOSS/sbt-git-hooks/actions/workflows/release.yml/badge.svg)](https://github.com/AbsaOSS/sbt-git-hooks/actions/workflows/release.yml)
 
 sbt-git-hooks is an [sbt](http://www.scala-sbt.org) plugin for maintaining git hooks as part of your code.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,23 @@
+# Release
+
+Releases of this sbt plugin are currently handled by [sbt-ci-release](https://github.com/sbt/sbt-ci-release).
+Please see its documentation for more details about how it works if you are interested to know more.
+
+The actual deployments are triggered manually by the maintainers of this repository, using `workflow_dispatch` event
+trigger.
+
+Once changes from a PR were reviewed and merged into the master branch, follow these steps:
+1. Create a new Git Tag and push it to the repository, to the master branch. For example,
+   if you want to release a version 0.4.0 (note that we are using [Semantic Versioning](https://semver.org/)):
+
+    ```shell
+    git tag -a v0.4.0 -m "v0.4.0"
+    git push origin v0.4.0
+    ```
+
+2. In GitHub UI, go to the repository's **Actions** -> **Release** -> **Run workflow**, and under **Use workflow from**
+   use **Tags** and find the tag you created in the previous step.
+
+   > **Important note**: don't run the workflow against the master branch, but against the tag.
+   > `sbt-ci-release` plugin won't be able to correctly find tag, and it will think that you are trying
+   > to do a snapshot release, not an actual release that should be synchronized with Maven Central.

--- a/publish.sbt
+++ b/publish.sbt
@@ -22,6 +22,7 @@ ThisBuild / scmInfo := Some(
     devConnection = "scm:git:ssh://github.com/AbsaOSS/sbt-git-hooks.git"
   )
 )
+ThisBuild / versionScheme := Some("early-semver")
 
 ThisBuild / developers := List(
   Developer(


### PR DESCRIPTION
Kind of a draft PR for now. It will contain a few status badges, I'm waiting for Maven Central to be synchronized with Nexus Sonatype (this plugin was recently deployed), so at the moment I cannot obtain the status badge for Maven Central.

I'm hoping to find it with this query within the next few hours/days: https://search.maven.org/search?q=sbt-git-hooks

EDIT: Ready for the review. Unfortunately, this plugin is not indexed properly on Maven Search, more details are here: https://issues.sonatype.org/browse/OSSRH-82998 and https://github.com/sbt/sbt/issues/3410. 